### PR TITLE
Bump CI to macOS 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
 
   build-intel:
     name: Build Intel-based package
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs:
       - "post-pending-status"
     outputs:


### PR DESCRIPTION
Per the changelog, macOS-10.15 support is dropped at the end of August.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/